### PR TITLE
Velocities + channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Click the cog at the bottom to set additional settings:
 - Max Notes Per Track - The number of notes that a single track can contain, before creating a new one
 - Length Type - Whether the `MIDI Length` should be in Ticks or Bars. If it is in ticks, the length will be dependent on the PPQ, and you will have to calculate it yourself. If it is in bars, the length will be translated to ticks for you
 - Trim Notes - Whether or not to trim the notes which go beyond the MIDI length
-- Note Velocity - Changes the notes' velocities
+- Min/Max Note Velocity - The minimum/maximum a note's velocity can be (if they are the same, there will be a constant velocity)
 - Note Channel - Changes what channel the notes will be generated in
 
 ## Building 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Random Note Generator
 A simple tool to randomly generate notes
 
-![Preview of the GUI](https://i.imgur.com/Mlp5tnZm.png)
+![Preview of the GUI](https://i.imgur.com/Mlp5tnZ.png)
 
 ## Purpose
 
@@ -26,6 +26,8 @@ Click the cog at the bottom to set additional settings:
 - Max Notes Per Track - The number of notes that a single track can contain, before creating a new one
 - Length Type - Whether the `MIDI Length` should be in Ticks or Bars. If it is in ticks, the length will be dependent on the PPQ, and you will have to calculate it yourself. If it is in bars, the length will be translated to ticks for you
 - Trim Notes - Whether or not to trim the notes which go beyond the MIDI length
+- Note Velocity - Changes the notes' velocities
+- Note Channel - Changes what channel the notes will be generated in
 
 ## Building 
 

--- a/gui.go
+++ b/gui.go
@@ -84,8 +84,7 @@ func createGUI() {
 			VelocityNumInput := createNumberInput(1, 127)
 
 			// Channel to use from 1 - 16
-			// TODO: "All (Skip Drums)", "All"
-			ChannelSelectInput := widget.NewSelect([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10 (Drums)", "11", "12", "13", "14", "15", "16"}, func(string) {})
+			ChannelSelectInput := widget.NewSelect([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10 (Drums)", "11", "12", "13", "14", "15", "16", "All (Skip Drums)", "All"}, func(string) {})
 
 			// turn into form FormItems
 			FormItems := []*widget.FormItem{

--- a/gui.go
+++ b/gui.go
@@ -84,7 +84,7 @@ func createGUI() {
 			VelocityNumInput := createNumberInput(1, 127)
 
 			// Channel to use from 1 - 16
-			ChannelSelectInput := widget.NewSelect([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10 (Drums)", "11", "12", "13", "14", "15", "16", "All (Skip Drums)", "All"}, func(string) {})
+			ChannelSelectInput := widget.NewSelect([]string{"All (Skip Drums)", "All", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10 (Drums)", "11", "12", "13", "14", "15", "16"}, func(string) {})
 
 			// turn into form FormItems
 			FormItems := []*widget.FormItem{

--- a/gui.go
+++ b/gui.go
@@ -83,12 +83,17 @@ func createGUI() {
 			// note velocity
 			VelocityNumInput := createNumberInput(1, 127)
 
+			// Channel to use from 1 - 16
+			// TODO: "All (Skip Drums)", "All"
+			ChannelSelectInput := widget.NewSelect([]string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10 (Drums)", "11", "12", "13", "14", "15", "16"}, func(string) {})
+
 			// turn into form FormItems
 			FormItems := []*widget.FormItem{
 				widget.NewFormItem("Max Notes Per Track", MaxNotesNumInput),
 				widget.NewFormItem("Length Type", LengthSelectInput),
 				widget.NewFormItem("Trim Notes", TrimNotesChkInput),
 				widget.NewFormItem("Note Velocity", VelocityNumInput),
+				widget.NewFormItem("Note Channel", ChannelSelectInput),
 			}
 
 			// set default values
@@ -96,6 +101,7 @@ func createGUI() {
 			LengthSelectInput.SetSelected(app.Preferences().StringWithFallback("lengthType", "MIDI Ticks"))
 			TrimNotesChkInput.SetChecked(app.Preferences().BoolWithFallback("trimNotes", true))
 			VelocityNumInput.SetText(app.Preferences().StringWithFallback("noteVelocity", "1"))
+			ChannelSelectInput.SetSelected(app.Preferences().StringWithFallback("noteChannel", "16"))
 
 			dialog.ShowForm("Settings", "Save", "Cancel", FormItems, func(b bool) {
 				if !b {
@@ -107,6 +113,7 @@ func createGUI() {
 				app.Preferences().SetString("lengthType", LengthSelectInput.Selected)
 				app.Preferences().SetBool("trimNotes", TrimNotesChkInput.Checked)
 				app.Preferences().SetString("noteVelocity", VelocityNumInput.Text)
+				app.Preferences().SetString("noteChannel", ChannelSelectInput.Selected)
 			}, window)
 		}),
 	)
@@ -209,6 +216,7 @@ func createGUI() {
 			trimNotes := app.Preferences().BoolWithFallback("trimNotes", true)
 			noteVelocity, err := strconv.Atoi(app.Preferences().StringWithFallback("noteVelocity", "1"))
 			handleErr(err)
+			noteChannel := app.Preferences().StringWithFallback("noteChannel", "16")
 
 			// if user selected MIDI Bars, convert the bars to ticks
 			lengthType := app.Preferences().StringWithFallback("lengthType", "MIDI Ticks")
@@ -244,7 +252,7 @@ func createGUI() {
 			// log the values
 			OutputLogTxt.SetText(
 				fmt.Sprintf(
-					"creating tracks | nc: %d | len: %d | maxlen: %d | minlen: %d | notesper: %d | trimnotes: %t | velocity: %d\n",
+					"creating tracks | nc: %d | len: %d | maxlen: %d | minlen: %d | notesper: %d | trimnotes: %t | velocity: %d | channel: %v\n",
 					noteCount,
 					ticks,
 					maxNoteLength,
@@ -252,6 +260,7 @@ func createGUI() {
 					maxNotesPerTrack,
 					trimNotes,
 					noteVelocity,
+					noteChannel,
 				),
 			)
 
@@ -264,6 +273,7 @@ func createGUI() {
 				maxNotesPerTrack,
 				trimNotes,
 				uint8(noteVelocity),
+				noteChannel,
 				func(format string, args ...any) {
 					OutputLogTxt.SetText(OutputLogTxt.Text + fmt.Sprintf(format, args...) + "\n")
 				},

--- a/midi.go
+++ b/midi.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Creates an array of tracks
-func createTracks(noteCount int, ticks int, maxNoteLength int, minNoteLength int, maxNotesPerTrack int, trimNotes bool, logger func(format string, a ...any)) []smf.Track {
+func createTracks(noteCount int, ticks int, maxNoteLength int, minNoteLength int, maxNotesPerTrack int, trimNotes bool, velocity uint8, logger func(format string, a ...any)) []smf.Track {
 	var (
 		tracks         []smf.Track
 		remainingNotes = noteCount
@@ -36,7 +36,7 @@ func createTracks(noteCount int, ticks int, maxNoteLength int, minNoteLength int
 
 		logger("generating track with %d notes | notes left: %d", nc, remainingNotes)
 
-		track := createTrack(nc, ticks, maxNoteLength, minNoteLength, trimNotes)
+		track := createTrack(nc, ticks, maxNoteLength, minNoteLength, trimNotes, velocity)
 		tracks = append(tracks, track)
 	}
 
@@ -45,7 +45,7 @@ func createTracks(noteCount int, ticks int, maxNoteLength int, minNoteLength int
 }
 
 // Creates a track, with a specified number of notes
-func createTrack(noteCount int, ticks int, maxNoteLength int, minNoteLength int, trimNotes bool) smf.Track {
+func createTrack(noteCount int, ticks int, maxNoteLength int, minNoteLength int, trimNotes bool, velocity uint8) smf.Track {
 	var (
 		track  smf.Track
 		events []NoteEvent
@@ -86,7 +86,7 @@ func createTrack(noteCount int, ticks int, maxNoteLength int, minNoteLength int,
 		}
 
 		if event.noteOn { // add note on event
-			track.Add(tick, midi.NoteOn(0, event.key, 127))
+			track.Add(tick, midi.NoteOn(0, event.key, velocity))
 		} else { // add note off event
 			track.Add(tick, midi.NoteOff(0, event.key))
 		}

--- a/midi.go
+++ b/midi.go
@@ -16,6 +16,7 @@ func createTracks(noteCount int, ticks int, maxNoteLength int, minNoteLength int
 		remainingNotes       = noteCount
 		specifiedChannel     = -1
 		currentChannelNumber = 0
+		trackCount           = 0
 	)
 
 	// get channel
@@ -66,14 +67,15 @@ func createTracks(noteCount int, ticks int, maxNoteLength int, minNoteLength int
 			// user selected "All (Skip Drums)"
 			// set the current channel based the current track number
 			// if the current channel is 9 (drums), skip it
-			currentChannelNumber = len(tracks) % 15
+			currentChannelNumber = trackCount % 16
 			if currentChannelNumber == 9 {
 				currentChannelNumber++ // skip drums
+				trackCount++           // increment track count to avoid double ch 11
 			}
 		} else if specifiedChannel == -2 {
 			// user selected "All"
 			// set the current channel based the current track number
-			currentChannelNumber = len(tracks) % 15
+			currentChannelNumber = trackCount % 16
 		} else {
 			// user selected a specific channel
 			currentChannelNumber = specifiedChannel
@@ -95,10 +97,11 @@ func createTracks(noteCount int, ticks int, maxNoteLength int, minNoteLength int
 			i = i + noteCount
 		}
 
-		logger("generating track (ch %d) with %d notes | notes left: %d", currentChannelNumber, nc, remainingNotes)
+		logger("generating track (ch %d) with %d notes | notes left: %d", currentChannelNumber+1, nc, remainingNotes)
 
 		track := createTrack(nc, ticks, maxNoteLength, minNoteLength, trimNotes, velocity, uint8(currentChannelNumber))
 		tracks = append(tracks, track)
+		trackCount++
 	}
 
 	logger("generated %d tracks", len(tracks))


### PR DESCRIPTION
**Random Note Velocities**
- users can now choose a min velocity and max velocity
- if max > min, will generate a random velocity for each note
- if max = min, will make all notes the same velocity

**Track Channels**
- users can now choose which channel the tracks should be in
- if channel = 1-16, all tracks will be in that specified channel.
- if channel = "All", will use all channels and go through 1-16 for each track
- if channel = "All (Skip Drums)", will use all channels (1-16) whilst skipping channel 10 (drum channel)

**Readme**
- updated readme to go along with these new additions